### PR TITLE
feat: Push image to Docker Hub as well

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,12 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
-      - name: Build and Push
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ryboe
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and Push to GHCR and Docker Hub
         uses: docker/build-push-action@v4
         with:
           build-args: |
@@ -28,7 +33,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           pull: true
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/openai:latest
+          tags: ghcr.io/${{ github.repository }}:latest,${{ github.repository }}:latest
           cache-from: type=gha
           # mode=max means "cache everything possible". This ensures maximum
           # use of the cache, but will use up GitHub's 10 GB cache size limit


### PR DESCRIPTION
Images on Docker Hub are more discoverable than those on GHCR.
